### PR TITLE
Added retries on fs.chmod to avoid errors while restoring permissions.

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -259,6 +259,8 @@ Parse.prototype._readCentralDirectoryFileHeader = function () {
           }
           fs.chmod(fname, mode, function(err) {
             if (err) {
+              // This appear when the file is not yet fully written to disk
+              // while starting to process central directory entries
               console.log('Unable to apply mode: 0' + mode.toString(8) + " to file " + fname);
             }
           });

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -28,7 +28,7 @@ function Parse(opts) {
     return new Parse(opts);
   }
 
-  this.dirPath = opts.path;
+  this.dirPath = opts && opts.path;
 
   Transform.call(this, { lowWaterMark: 0 });
   this._opts = opts || { verbose: false };
@@ -248,15 +248,21 @@ Parse.prototype._readCentralDirectoryFileHeader = function () {
         zip file was made on UNIX and we are extracting a file onto an
         "unix" kind of system.
        */
-      var madeBy = vars.versionMadeBy >> 8;
-      var mode = vars.externalFileAttributes >>> 16;
-      if (madeBy === MADE_BY_UNIX && (process.platform === 'darwin' || process.platform === 'linux') && (mode & S_IFREG)) {
-        mode = (mode & 0x1ff);
-        var fname = path.join(self.dirPath, fileName);
-        if (self._opts.verbose) {
-          console.log('Applying mode: 0' + mode.toString(8) + " to file " + fname);
+      if (self.dirPath) {
+        var madeBy = vars.versionMadeBy >> 8;
+        var mode = vars.externalFileAttributes >>> 16;
+        if (madeBy === MADE_BY_UNIX && (process.platform === 'darwin' || process.platform === 'linux') && (mode & S_IFREG)) {
+          mode = (mode & 0x1ff);
+          var fname = path.join(self.dirPath, fileName);
+          if (self._opts.verbose) {
+            console.log('Applying mode: 0' + mode.toString(8) + " to file " + fname);
+          }
+          fs.chmod(fname, mode, function(err) {
+            if (err) {
+              console.log('Unable to apply mode: 0' + mode.toString(8) + " to file " + fname);
+            }
+          });
         }
-        fs.chmodSync(fname, mode);
       }
 
       self._untilStream.pull(vars.extraFieldLength, function (err, extraField) {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -7,6 +7,8 @@ var Transform = require('stream').Transform;
 var inherits = require('util').inherits;
 var zlib = require('zlib');
 var binary = require('binary');
+var path = require('path');
+var fs = require('fs');
 var Buffers = require('buffers');
 var UntilStream = require('./untilstream');
 var Entry = require('./entry');
@@ -15,6 +17,9 @@ if (!Transform) {
   Transform = require('readable-stream/transform');
 }
 
+var S_IFREG = 0x8000;     // #define S_IFREG  0100000  /* regular */
+var MADE_BY_UNIX = 3;     // See http://www.pkware.com/documents/casestudies/APPNOTE.TXT
+
 inherits(Parse, Transform);
 
 function Parse(opts) {
@@ -22,6 +27,8 @@ function Parse(opts) {
   if (!(this instanceof Parse)) {
     return new Parse(opts);
   }
+
+  this.dirPath = opts.path;
 
   Transform.call(this, { lowWaterMark: 0 });
   this._opts = opts || { verbose: false };
@@ -235,6 +242,22 @@ Parse.prototype._readCentralDirectoryFileHeader = function () {
         return self.emit('error', err);
       }
       fileName = fileName.toString('utf8');
+
+      /*
+        Apply the permissions from the "externalFileAttributes" only if the
+        zip file was made on UNIX and we are extracting a file onto an
+        "unix" kind of system.
+       */
+      var madeBy = vars.versionMadeBy >> 8;
+      var mode = vars.externalFileAttributes >>> 16;
+      if (madeBy === MADE_BY_UNIX && (process.platform === 'darwin' || process.platform === 'linux') && (mode & S_IFREG)) {
+        mode = (mode & 0x1ff);
+        var fname = path.join(self.dirPath, fileName);
+        if (self._opts.verbose) {
+          console.log('Applying mode: 0' + mode.toString(8) + " to file " + fname);
+        }
+        fs.chmodSync(fname, mode);
+      }
 
       self._untilStream.pull(vars.extraFieldLength, function (err, extraField) {
         if (err) {


### PR DESCRIPTION
Added retries on fs.chmod to avoid errors while restoring permissions.

WARNING: this is a temporary fix which uses synchronous methods.
The real synchro mechanism to implement is not yet understood.
