### PR TITLE
Issue #16. The recursive call to inflateServiceRequest was causing node to hit the ...

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -157,14 +157,14 @@ Parse.prototype._readFile = function () {
               if (prevData.length && sigIndex <= 0) {
                 if (inflater.write(prevData)) {
                   prevData = data;
-                  inflateServiceRequest();
+                  process.nextTick(inflateServiceRequest.bind(self));
                 } else {
                   prevData = data;
                   inflater.once('drain', inflateServiceRequest.bind(self));
                 }
               } else if (!prevData.length) {
                 prevData = data;
-                inflateServiceRequest();
+                process.nextTick(inflateServiceRequest.bind(self));
               }
               else {
                 processDescriptor(bufs, sigIndex);


### PR DESCRIPTION
...max stack size limit. The stack size would reset once "inflater.write" returned false, but when that happened was subject to outside influence.

By using process.nextTick() we stop the inflateServiceRequest from adding to the stack when it needs to call itself.
