### PR TITLE
Parse.prototype.addListener should behave like EventEmitter.addListener

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -312,7 +312,7 @@ Parse.prototype.addListener = function(type, listener) {
   if ('entry' === type) {
     this._hasEntryListener = true;
   }
-  Transform.prototype.addListener.call(this, type, listener);
+  return Transform.prototype.addListener.call(this, type, listener);
 };
 
 Parse.prototype.on = Parse.prototype.addListener;


### PR DESCRIPTION
Without this change we're breaking standard EventEmitter behavior and
removing the ability to chain .on() & .addListener() functions.
