### PR TITLE
Fix maximum call stack size exceeded

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -155,19 +155,18 @@ Parse.prototype._readFile = function () {
             var descriptorSig = new Buffer(4);
             descriptorSig.writeUInt32LE(0x08074b50, 0);
 
-            var matchStream = new MatchStream({ pattern: descriptorSig }, function (buf, matched, extra) {
+            var matchStream = new MatchStream({ pattern: descriptorSig }, function (buf, matched) {
               if (!matched) {
                 return hasEntryListener ? this.push(buf) : null;
               }
+              self._pullStream.unpipe();
               if (hasEntryListener) {
                 this.push(buf);
               }
-              process.nextTick(function() {
-                self._pullStream.unpipe();
-                self._pullStream.prepend(extra);
-                self._processDataDescriptor(entry);
-              });
-              return this.push(null);
+              this.end();
+            }, function (extra) {
+              self._pullStream.prepend(extra);
+              self._processDataDescriptor(entry);
             });
 
             self._pullStream.pipe(matchStream);

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -240,7 +240,7 @@ Parse.prototype._readCentralDirectoryFileHeader = function () {
           if (err) {
             return self.emit('error', err);
           }
-          return self._readRecord();
+          return setImmediate(self._readRecord.bind(self));
         });
       });
     });

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -162,7 +162,7 @@ Parse.prototype._readFile = function () {
               if (hasEntryListener) {
                 this.push(buf);
               }
-              setImmediate(function() {
+              process.nextTick(function() {
                 self._pullStream.unpipe();
                 self._pullStream.prepend(extra);
                 self._processDataDescriptor(entry);

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -156,10 +156,10 @@ Parse.prototype._readFile = function () {
             descriptorSig.writeUInt32LE(0x08074b50, 0);
 
             var matchStream = new MatchStream({ pattern: descriptorSig }, function (buf, matched, extra) {
+              if (!matched) {
+                return hasEntryListener ? this.push(buf) : null;
+              }
               if (hasEntryListener) {
-                if (!matched) {
-                  return this.push(buf);
-                }
                 this.push(buf);
               }
               setImmediate(function() {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "binary": "~0.3.0",
     "readable-stream": "~1.0.0",
     "setimmediate": "~1.0.1",
-    "match-stream": "~0.0.2"
+    "match-stream": "git://github.com/EvanOxfeld/match-stream.git#callback-on-finish-wip"
   },
   "devDependencies": {
     "tap": "~0.3.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "binary": "~0.3.0",
     "readable-stream": "~1.0.0",
     "setimmediate": "~1.0.1",
-    "match-stream": "0.0.1"
+    "match-stream": "~0.0.2"
   },
   "devDependencies": {
     "tap": "~0.3.0",


### PR DESCRIPTION
Most of the way fix for #16. Working in node 0.10.3 on jquery-ui-1.10.0.custom.zip but not in node 0.8.x testing against

``` javascript
var unzip = require('unzip');
var fs = require('fs');

fs.createReadStream('jquery-ui-1.10.0.custom.zip')
    .pipe(unzip.Extract({ path: 'test' }))
    .on('error', function (err) { console.log('error', err); })
    .on('close', function () { console.log('closed'); });
```

Current hang up is 34f30cc3c47c9792fbce7c8dbb48b59463bd9555 and more specifically the MatchStream starting on parse.js line 158. For archives that contain variable length file data, unzip.Parse needs to stop sending data to the zlib inflater stream when the data descriptor signature is reached. In Node 0.10.x the MatchStream stops the flow of data correctly because the process.nextTick on line 165 happens on the current tick before I/O. Unfortunately, in Node 0.8.x I/O can happen before a process.nextTick, which causes extra writes to the MatchStream and erroneous data to flow into the zlib inflater stream.

Feedback is much appreciated.

/cc @satazor
