### PR TITLE
Ignore test items in the npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+test/
+testData/


### PR DESCRIPTION
Ignore test items in the npm package
### What?

Add a `.npmignore` file to skip `test` and `testData` folders.
### Why?

Skip unnecessary data from the package, to get only the necessary stuff in users `node_modules`. See [npm-developers](https://npmjs.org/doc/developers.html). For this project, that's 64 Ko less to download for users.
### Test?

Folders are indeed skipped. Should not change anything in the rest of the lib., test data is not supposed to be needed in prod. Does not change anything for the test suite itself.
