### PR TITLE
fix error in entry type judgment

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -94,7 +94,7 @@ Parse.prototype._readFile = function () {
       var entry = new Entry();
       entry.path = fileName;
       entry.props.path = fileName;
-      entry.type = (vars.compressedSize === 0 && /[\/\\]$/.test(fileName)) ? 'Directory' : 'File';
+      entry.type = (/[\/\\]$/.test(fileName)) ? 'Directory' : 'File';
 
       if (self._opts.verbose) {
         if (entry.type === 'Directory') {


### PR DESCRIPTION
There is no need to test compressedSize is 0 or not, just to check if the file name ends with '/'.
Following is the code snippet from Java SDK ( java.util.ZipEntry)
<code>
  /**
     \* Returns true if this is a directory entry. A directory entry is
     \* defined to be one whose name ends with a '/'.
     \* @return true if this is a directory entry
     */
    public boolean isDirectory() {
        return name.endsWith("/");
    }
</code>
