### PR TITLE
handle slowly progressing streams

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -158,8 +158,8 @@ Parse.prototype._readFile = function () {
                 }
                 this.push(buf);
               }
+              self._pullStream.unpipe();
               setImmediate(function() {
-                self._pullStream.unpipe();
                 self._pullStream.prepend(extra);
                 self._processDataDescriptor(entry);
               });


### PR DESCRIPTION
I was trying to download zip with request and pipe it to Parse

``` javascript
  dl_stream = request.get('....');
  dl_stream.pipe(unzip.Parse())
  .on('entry', function(entry) { ...
```

it failed to extract files because MatchStream get some data before setImmediate was executed
