### PR TITLE
Fixed issue 37, where entry.size is undefined.

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -86,11 +86,19 @@ Parse.prototype._readFile = function () {
       if (err) {
         return self.emit('error', err);
       }
-      fileName = fileName.toString('utf8');
+
       var entry = new Entry();
+      var fileSizeKnown = !(vars.flags & 0x08);
+
+      fileName = fileName.toString('utf8');
+
       entry.path = fileName;
       entry.props.path = fileName;
       entry.type = (vars.compressedSize === 0 && /[\/\\]$/.test(fileName)) ? 'Directory' : 'File';
+
+      if (entry.type === 'File' && fileSizeKnown) {
+        entry.size = vars.uncompressedSize;
+      }
 
       if (self._opts.verbose) {
         if (entry.type === 'Directory') {
@@ -127,15 +135,12 @@ Parse.prototype._readFile = function () {
             return self._readRecord();
           });
         } else {
-          var fileSizeKnown = !(vars.flags & 0x08);
-
           var inflater = zlib.createInflateRaw();
           inflater.on('error', function (err) {
             self.emit('error', err);
           });
 
           if (fileSizeKnown) {
-            entry.size = vars.uncompressedSize;
             if (hasEntryListener) {
               entry.on('finish', self._readRecord.bind(self));
               self._pullStream.pipe(vars.compressedSize, inflater).pipe(entry);


### PR DESCRIPTION
This is just a real quick first pass, with little knowledge of the rest of the codebase. The crux of the issue is that entry.size is unassigned before the "entry" event is emitted. I couldn't find anywhere where vars.uncompressedSize and vars.flags are re-assigned between the initial assignment and the usage after fileSizeKnown. So, I just moved that block up before "entry" is emitted.
