### PR TITLE
Update and organize deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,18 +19,18 @@
   },
   "license": "MIT",
   "dependencies": {
-    "fstream": ">= 0.1.30 < 1",
-    "pullstream": ">= 0.4.1 < 1",
-    "binary": ">= 0.3.0 < 1",
-    "readable-stream": "~1.0.31",
-    "setimmediate": ">= 1.0.1 < 2",
-    "match-stream": ">= 0.0.2 < 1"
+    "binary": "^0.3.0",
+    "fstream": "^1.0.8",
+    "match-stream": "0.0.2",
+    "pullstream": "^0.4.1",
+    "readable-stream": "^2.1.2",
+    "setimmediate": "^1.0.4"
   },
   "devDependencies": {
-    "tap": ">= 0.3.0 < 1",
-    "temp": ">= 0.4.0 < 1",
-    "dirdiff": ">= 0.0.1 < 1",
-    "stream-buffers": ">= 0.2.5 < 1"
+    "dirdiff": "0.0.1",
+    "stream-buffers": "^0.2.5",
+    "tap": "^5.7.1",
+    "temp": "^0.8.3"
   },
   "directories": {
     "example": "examples",


### PR DESCRIPTION
I updated the dependencies of this module to fix an issue with the `fstream` dependency specifically. Related to https://github.com/bluesmoon/node-geoip/issues/107 and node 6.

If there are any changes needed to the PR let me know. If this library is no longer maintained please let me know so I can create a fork instead.
