### PR TITLE
Update fstream dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "fstream": ">= 0.1.30 < 1",
+    "fstream": "^1.0.9",
     "pullstream": ">= 0.4.1 < 1",
     "binary": ">= 0.3.0 < 1",
     "readable-stream": "~1.0.31",


### PR DESCRIPTION
The older fstream module depends on graceful-fs 3.x which will fail on Node.js 6.x.
