### PR TITLE
Fix `finish` and `close`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: node_js
 node_js:
   - "0.11"
   - "0.10"
-  - "0.8"
+
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -27,11 +27,9 @@ function Parse(opts) {
   this._pullStream.on("error", function (e) {
     self.emit('error', e);
   });
-  this._pullStream.once("end", function () {
-    self._streamEnd = true;
-  });
   this._pullStream.once("finish", function () {
-    self._streamFinish = true;
+    Transform.prototype.end.call(self);
+      self.emit('close');
   });
 
   this._readRecord();
@@ -295,13 +293,9 @@ Parse.prototype.pipe = function (dest, opts) {
   return Transform.prototype.pipe.apply(this, arguments);
 };
 
-Parse.prototype._flush = function (callback) {
-  if (!this._streamEnd || !this._streamFinish) {
-    return setImmediate(this._flush.bind(this, callback));
-  }
-
-  this.emit('close');
-  return callback();
+Parse.prototype.end = function(d,e,cb) {
+  if (typeof cb === 'function')
+    cb();
 };
 
 Parse.prototype.addListener = function(type, listener) {


### PR DESCRIPTION
Under some circumstances the unzip stream can end up in limbo without emitting `finish` or `close`.   Here we simplify the end mechanism as follows:
- `end` on the main stream does nothing, because we dont want to end until the pullsteam is done
- When pullstream is `finished` the prototype `end` function is applied to the unzip stream and `close` is emitted
