### PR TITLE
handle finish and error events to avoid dead _flush loop

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -34,6 +34,14 @@ function Parse(opts) {
     self._streamFinish = true;
   });
 
+  this.once('error',function () {
+    this.isError = true
+  })
+
+  this.once('finish',function () {
+    this.isFinish = true
+  })
+
   this._readRecord();
 }
 
@@ -296,7 +304,7 @@ Parse.prototype.pipe = function (dest, opts) {
 };
 
 Parse.prototype._flush = function (callback) {
-  if (!this._streamEnd || !this._streamFinish) {
+  if (!this.isFinish && !this.isError &&( !this._streamEnd || !this._streamFinish)) {
     return setImmediate(this._flush.bind(this, callback));
   }
 


### PR DESCRIPTION

[samples.zip](https://github.com/EvanOxfeld/node-unzip/files/1678258/samples.zip)


sample zip files will cause unzip in dead _flush loop, handle the error and finish events can avoid this.