### PR TITLE
Add `.nyc_output` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /.idea
 /node_modules
+.nyc_output
+


### PR DESCRIPTION
When running `npm test`, the output is put into the `nyc_output`
directory. This data is not relevant to the master repository and should
be ignored by `git`.

This commit adds `.nyc_output` to the `.gitignore` so that the output
from `npm test` is not erroneously added to a commit.