### PR TITLE
Upgraded version of fstream to 1.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
   },
   "license": "MIT",
   "dependencies": {
-    "fstream": ">= 0.1.30 < 1",
-    "pullstream": ">= 0.4.1 < 1",
     "binary": ">= 0.3.0 < 1",
+    "fstream": "^1.0.12",
+    "match-stream": ">= 0.0.2 < 1",
+    "pullstream": ">= 0.4.1 < 1",
     "readable-stream": "~1.0.31",
-    "setimmediate": ">= 1.0.1 < 2",
-    "match-stream": ">= 0.0.2 < 1"
+    "setimmediate": ">= 1.0.1 < 2"
   },
   "devDependencies": {
     "tap": ">= 0.3.0 < 1",


### PR DESCRIPTION
Continuously getting this warning (https://www.npmjs.com/advisories/886) while trying to work with 'unzip' package in node. As a fix to the same problem, upgrading the version of 'fstream' package. Tested and working fine.