### PR TITLE
update fstream version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "fstream": ">= 0.1.30 < 1",
+    "fstream": "~1.0.12",
     "pullstream": ">= 0.4.1 < 1",
     "binary": ">= 0.3.0 < 1",
     "readable-stream": "~1.0.31",


### PR DESCRIPTION
Fstream has older version of graceful-fs which is not compatible with node 18